### PR TITLE
TW-45411 Fix inconsistent XML format

### DIFF
--- a/agent/src/jetbrains/buildServer/symbols/SymbolsIndexer.java
+++ b/agent/src/jetbrains/buildServer/symbols/SymbolsIndexer.java
@@ -150,7 +150,7 @@ public class SymbolsIndexer extends ArtifactsBuilderAdapter {
       myArtifactsWatcher.addNewArtifactsPath(guidDumpFile + "=>" + ".teamcity/symbols");
     }
     if(guidDumpFile.isFile())
-      return PdbSignatureIndexUtil.read(new FileInputStream(guidDumpFile));
+      return PdbSignatureIndexUtil.read(new FileInputStream(guidDumpFile), true);
     else
       return Collections.emptySet();
   }

--- a/common/src/jetbrains/buildServer/symbols/PdbSignatureIndexUtil.java
+++ b/common/src/jetbrains/buildServer/symbols/PdbSignatureIndexUtil.java
@@ -23,13 +23,13 @@ class PdbSignatureIndexUtil {
   private static final String FILE_SIGN_ENTRY = "file-sign-entry";
 
   @NotNull
-  static Set<PdbSignatureIndexEntry> read(@NotNull final InputStream inputStream) throws JDOMException, IOException {
+  static Set<PdbSignatureIndexEntry> read(@NotNull final InputStream inputStream, final boolean withDebugType) throws JDOMException, IOException {
     final SAXBuilder builder = new SAXBuilder();
     final Document document = builder.build(inputStream);
     final Set<PdbSignatureIndexEntry> result = new HashSet<PdbSignatureIndexEntry>();
     for (Object signElementObject : document.getRootElement().getChildren()){
       final Element signElement = (Element) signElementObject;
-      result.add(new PdbSignatureIndexEntry(extractGuid(signElement.getAttributeValue(SIGN)), signElement.getAttributeValue(FILE_NAME), signElement.getAttributeValue(FILE_PATH)));
+      result.add(new PdbSignatureIndexEntry(extractGuid(signElement.getAttributeValue(SIGN), withDebugType), signElement.getAttributeValue(FILE_NAME), signElement.getAttributeValue(FILE_PATH)));
     }
     return result;
   }
@@ -49,7 +49,10 @@ class PdbSignatureIndexUtil {
     XmlUtil.saveDocument(new Document(root), outputStream);
   }
 
-  private static String extractGuid(String sign) {
-    return sign.substring(0, sign.length() - 1).toLowerCase(); //last symbol is PEDebugType
+  private static String extractGuid(String sign, boolean withDebugType) {
+    if (withDebugType)
+      return sign.substring(0, sign.length() - 1).toLowerCase(); //last symbol is PEDebugType
+    else
+      return sign.toLowerCase();
   }
 }

--- a/jet-symbols/src/JetBrains.CommandLine.Symbols/DumpFilesSignCommandBase.cs
+++ b/jet-symbols/src/JetBrains.CommandLine.Symbols/DumpFilesSignCommandBase.cs
@@ -51,7 +51,8 @@ namespace JetBrains.CommandLine.Symbols
       foreach (KeyValuePair<FileSystemPath, string> signature in signatures)
       {
         XmlElement element = node.CreateElement("file-sign-entry");
-        element.CreateAttributeWithNonEmptyValue("file", signature.Key.FullPath);
+        element.CreateAttributeWithNonEmptyValue("file-path", signature.Key.FullPath);
+        element.CreateAttributeWithNonEmptyValue("file", signature.Key.Name);
         string str = signature.Value;
         if (str != null)
           element.CreateAttributeWithNonEmptyValue("sign", str);

--- a/server/src/jetbrains/buildServer/symbols/BuildSymbolsIndexProvider.java
+++ b/server/src/jetbrains/buildServer/symbols/BuildSymbolsIndexProvider.java
@@ -52,7 +52,7 @@ public class BuildSymbolsIndexProvider implements BuildMetadataProvider {
 
     Set<PdbSignatureIndexEntry> indexEntries = Collections.emptySet();
     try {
-      indexEntries = PdbSignatureIndexUtil.read(symbolSignaturesSource.getInputStream());
+      indexEntries = PdbSignatureIndexUtil.read(symbolSignaturesSource.getInputStream(), false);
     } catch (IOException e) {
       LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
     } catch (JDOMException e) {


### PR DESCRIPTION
I address two issues in this pull request that fix [TW-45411](https://youtrack.jetbrains.com/issue/TW-45411).
1. The GUID dumper now exports in the expected XML format.
2. The PEDebugType is not stripped from the GUID a second time anymore.

Bug no. 2 is clearly visible from the log files:

``` xml
<!-- artifacts.xml -->
<file-signs>
  <file-sign-entry sign="67c37c5a7a724c0eb8f74410446602a4" file="X.pdb" file-path="output.zip!/x64/X.pdb"/>
  <file-sign-entry sign="0c2d8ad1d7304b1485b79fa6dfb63176" file="X.pdb" file-path="output.zip!/x86/X.pdb"/>
</file-signs>
```

Logs when the symbols are indexed: _(note that the last character of the GUID is missing)_

```
[2016-06-02 14:05:06,972]  DEBUG - bols.BuildSymbolsIndexProvider - Build with id 3841 provides 2 symbol file signatures. 
[2016-06-02 14:05:06,972]  DEBUG - bols.BuildSymbolsIndexProvider - Stored symbol file signature 67c37c5a7a724c0eb8f74410446602a for file name X.pdb build id 3841 
[2016-06-02 14:05:06,972]  DEBUG - bols.BuildSymbolsIndexProvider - Stored symbol file signature 0c2d8ad1d7304b1485b79fa6dfb6317 for file name X.pdb build id 3841 
[2016-06-02 14:05:06,972]  DEBUG - mpl.indexer.BuildMetadataIndex - Succesfully updated symbols-index-provider provider metadata for build Running build bt56 on Bot, build id: 3841.
```

Logs when the symbols are requested:

```
[2016-06-02 14:17:56,927]  DEBUG - bols.DownloadSymbolsController - Symbol file requested. File name: X.pdb. Guid: 67c37c5a7a724c0eb8f74410446602a4. 
[2016-06-02 14:17:56,927]  DEBUG - bols.DownloadSymbolsController - There is no information about symbol file with id 67c37c5a7a724c0eb8f74410446602a4 in the index. 
```
