### PR TITLE
Add ability to index exes and dlls as well as pdbs

### DIFF
--- a/agent-tests/src/jetbrains/buildServer/symbols/JetSymbolsExeTest.java
+++ b/agent-tests/src/jetbrains/buildServer/symbols/JetSymbolsExeTest.java
@@ -32,7 +32,7 @@ public class JetSymbolsExeTest extends BaseTestCase {
   @Test
   public void testCmdParametersLengthLimit() throws Exception {
     final File output = FileUtil.createTempFile("testCmdParametersLengthLimit", ".out");
-    final int dumpExitCode = myExe.dumpGuidsToFile(getFilesCollection(500), output, new NullBuildProgressLogger());
+    final int dumpExitCode = myExe.dumpPdbGuidsToFile(getFilesCollection(500), output, new NullBuildProgressLogger());
     assertEquals(0, dumpExitCode);
   }
 
@@ -40,7 +40,7 @@ public class JetSymbolsExeTest extends BaseTestCase {
   public void testSpacesInPaths() throws Exception {
     final File output = FileUtil.createTempFile("test spaces in paths", ".out");
     final File input = FileUtil.createTempFile("test spaces in paths", ".in");
-    final int exitCode = myExe.dumpGuidsToFile(Collections.singleton(input), output, new NullBuildProgressLogger());
+    final int exitCode = myExe.dumpPdbGuidsToFile(Collections.singleton(input), output, new NullBuildProgressLogger());
     assertEquals(0, exitCode);
   }
 

--- a/agent/src/jetbrains/buildServer/symbols/SymbolsIndexer.java
+++ b/agent/src/jetbrains/buildServer/symbols/SymbolsIndexer.java
@@ -209,7 +209,7 @@ public class SymbolsIndexer extends ArtifactsBuilderAdapter {
       myArtifactsWatcher.addNewArtifactsPath(guidDumpFile + "=>" + ".teamcity/symbols");
     }
     if(guidDumpFile.isFile())
-      return PdbSignatureIndexUtil.read(new FileInputStream(guidDumpFile));
+      return PdbSignatureIndexUtil.read(new FileInputStream(guidDumpFile), true);
     else
       return Collections.emptySet();
   }
@@ -221,7 +221,7 @@ public class SymbolsIndexer extends ArtifactsBuilderAdapter {
       myArtifactsWatcher.addNewArtifactsPath(guidDumpFile + "=>" + ".teamcity/symbols");
     }
     if(guidDumpFile.isFile())
-      return PdbSignatureIndexUtil.read(new FileInputStream(guidDumpFile));
+      return PdbSignatureIndexUtil.read(new FileInputStream(guidDumpFile), true);
     else
       return Collections.emptySet();
   }

--- a/agent/src/jetbrains/buildServer/symbols/SymbolsIndexer.java
+++ b/agent/src/jetbrains/buildServer/symbols/SymbolsIndexer.java
@@ -95,15 +95,7 @@ public class SymbolsIndexer extends ArtifactsBuilderAdapter {
               LOG.warn("No information was collected about symbol files signatures");
               myProgressLogger.warning("No information was collected about symbol files signatures");
             } else {
-              final Set<PdbSignatureIndexEntry> indexData = new HashSet<PdbSignatureIndexEntry>();
-              for(PdbSignatureIndexEntry signatureIndexEntry : signatureLocalFilesData){
-                final String artifactPath = signatureIndexEntry.getArtifactPath();
-                if(artifactPath == null) continue;
-                final File targetPdbFile = new File(artifactPath);
-                if(myPdbFileToArtifactMapToProcess.containsKey(targetPdbFile)) {
-                  indexData.add(new PdbSignatureIndexEntry(signatureIndexEntry.getGuid(), targetPdbFile.getName(), myPdbFileToArtifactMapToProcess.get(targetPdbFile)));
-                }
-              }
+              final Set<PdbSignatureIndexEntry> indexData = getSignatureIndexEntries(signatureLocalFilesData, myPdbFileToArtifactMapToProcess);
               final File indexDataFile = FileUtil.createTempFile(myBuildTempDirectory, SymbolsConstants.SYMBOL_SIGNATURES_FILE_NAME_PREFIX, ".xml", false);
               PdbSignatureIndexUtil.write(new FileOutputStream(indexDataFile), indexData);
               myProgressLogger.message("Publishing collected symbol files signatures.");
@@ -129,15 +121,7 @@ public class SymbolsIndexer extends ArtifactsBuilderAdapter {
               LOG.warn("No information was collected about binary files signatures");
               myProgressLogger.warning("No information was collected about binary files signatures");
             } else {
-              final Set<PdbSignatureIndexEntry> indexData = new HashSet<PdbSignatureIndexEntry>();
-              for(PdbSignatureIndexEntry signatureIndexEntry : signatureLocalFilesData){
-                final String artifactPath = signatureIndexEntry.getArtifactPath();
-                if(artifactPath == null) continue;
-                final File targetBinaryFile = new File(artifactPath);
-                if(myBinaryFileToArtifactMapToProcess.containsKey(targetBinaryFile)) {
-                  indexData.add(new PdbSignatureIndexEntry(signatureIndexEntry.getGuid(), targetBinaryFile.getName(), myBinaryFileToArtifactMapToProcess.get(targetBinaryFile)));
-                }
-              }
+              final Set<PdbSignatureIndexEntry> indexData = getSignatureIndexEntries(signatureLocalFilesData, myBinaryFileToArtifactMapToProcess);
               final File indexDataFile = FileUtil.createTempFile(myBuildTempDirectory, SymbolsConstants.BINARY_SIGNATURES_FILE_NAME_PREFIX, ".xml", false);
               PdbSignatureIndexUtil.write(new FileOutputStream(indexDataFile), indexData);
               myProgressLogger.message("Publishing collected binary files signatures.");
@@ -150,6 +134,20 @@ public class SymbolsIndexer extends ArtifactsBuilderAdapter {
           }
         }
         myBinaryFileToArtifactMapToProcess.clear();
+      }
+
+      @NotNull
+      private Set<PdbSignatureIndexEntry> getSignatureIndexEntries(Set<PdbSignatureIndexEntry> signatureLocalFilesData, Map<File, String> artifactMap) {
+        final Set<PdbSignatureIndexEntry> indexData = new HashSet<PdbSignatureIndexEntry>();
+        for(PdbSignatureIndexEntry signatureIndexEntry : signatureLocalFilesData){
+          final String artifactPath = signatureIndexEntry.getArtifactPath();
+          if(artifactPath == null) continue;
+          final File targetFile = new File(artifactPath);
+          if(artifactMap.containsKey(targetFile)) {
+            indexData.add(new PdbSignatureIndexEntry(signatureIndexEntry.getGuid(), targetFile.getName(), artifactMap.get(targetFile)));
+          }
+        }
+        return indexData;
       }
     });
   }

--- a/agent/src/jetbrains/buildServer/symbols/tools/BinaryGuidDumper.java
+++ b/agent/src/jetbrains/buildServer/symbols/tools/BinaryGuidDumper.java
@@ -1,0 +1,63 @@
+package jetbrains.buildServer.symbols.tools;
+
+import jetbrains.buildServer.agent.BuildProgressLogger;
+import jetbrains.buildServer.util.XmlUtil;
+import org.jdom.Document;
+import org.jdom.Element;
+
+import java.io.*;
+import java.util.Collection;
+
+/**
+ * Created by maldorasi on 8/8/16.
+ */
+public class BinaryGuidDumper {
+    public static void dumpBinaryGuidsToFile(Collection<File> files, File output, BuildProgressLogger buildLogger) {
+        final Element root = new Element("file-signs");
+        for (File file : files) {
+            RandomAccessFile randomAccess = null;
+            try {
+                randomAccess = new RandomAccessFile(file, "r");
+                //the PE offset is at byte [60,64)
+                int peOffset = readIntLE(randomAccess, 60);
+                int timestamp = readIntLE(randomAccess, peOffset + 8);
+                int size = readIntLE(randomAccess, peOffset + 80);
+                String signature = Integer.toHexString(timestamp) + Integer.toHexString(size);
+                final Element entry = new Element("file-sign-entry");
+                entry.setAttribute("file-path", file.getPath());
+                entry.setAttribute("file", file.getName());
+                entry.setAttribute("sign", signature);
+                root.addContent(entry);
+            } catch (IOException e) {
+                buildLogger.exception(e);
+            } finally {
+                if (randomAccess != null)
+                    try {
+                        randomAccess.close();
+                    } catch (IOException e) {
+                        //I hate you, checked exceptions
+                        buildLogger.exception(e);
+                    }
+            }
+        }
+        try {
+            XmlUtil.saveDocument(new Document(root), new FileOutputStream(output));
+        } catch (IOException e) {
+            buildLogger.exception(e);
+        }
+    }
+
+    private static int readIntLE(RandomAccessFile file, long position) throws IOException {
+        file.seek(position);
+        byte[] bytes = new byte[4];
+        int bytesRead = file.read(bytes);
+        if (bytesRead != bytes.length) {
+            throw new EOFException();
+        }
+        return (bytes[0] & 0xff) +
+                ((bytes[1] & 0xff) << 8) +
+                ((bytes[2] & 0xff) << 16) +
+                ((bytes[3] & 0xff) << 24);
+    }
+
+}

--- a/agent/src/jetbrains/buildServer/symbols/tools/JetSymbolsExe.java
+++ b/agent/src/jetbrains/buildServer/symbols/tools/JetSymbolsExe.java
@@ -5,9 +5,11 @@ import jetbrains.buildServer.ExecResult;
 import jetbrains.buildServer.SimpleCommandLineProcessRunner;
 import jetbrains.buildServer.agent.BuildProgressLogger;
 import jetbrains.buildServer.util.FileUtil;
+import jetbrains.buildServer.util.XmlUtil;
+import org.jdom.Document;
+import org.jdom.Element;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.util.Collection;
 
 /**
@@ -23,7 +25,7 @@ public class JetSymbolsExe {
     myExePath = new File(homeDir, SYMBOLS_EXE);
   }
 
-  public int dumpGuidsToFile(Collection<File> files, File output, BuildProgressLogger buildLogger) throws IOException {
+  public int dumpPdbGuidsToFile(Collection<File> files, File output, BuildProgressLogger buildLogger) throws IOException {
     final GeneralCommandLine commandLine = new GeneralCommandLine();
     commandLine.setExePath(myExePath.getPath());
     commandLine.addParameter(DUMP_SYMBOL_SIGN_CMD);
@@ -46,6 +48,54 @@ public class JetSymbolsExe {
       }
     }
     return exitCode;
+  }
+
+  public void dumpBinaryGuidsToFile(Collection<File> files, File output, BuildProgressLogger buildLogger)
+  {
+    final Element root = new Element("file-signs");
+    for (File file : files) {
+      RandomAccessFile randomAccess = null;
+      try {
+        randomAccess = new RandomAccessFile(file, "r");
+        //the PE offset is at byte [60,64)
+        int peOffset = readIntLE(randomAccess, 60);
+        int timestamp = readIntLE(randomAccess, peOffset + 8);
+        int size = readIntLE(randomAccess, peOffset + 80);
+        String signature = Integer.toHexString(timestamp) + Integer.toHexString(size);
+        final Element entry = new Element("file-sign-entry");
+        entry.setAttribute("file", file.getPath());
+        entry.setAttribute("sign", signature);
+        root.addContent(entry);
+      } catch (IOException e) {
+        buildLogger.exception(e);
+      } finally {
+        if (randomAccess != null)
+          try {
+            randomAccess.close();
+          } catch (IOException e) {
+            //I hate you, checked exceptions
+            buildLogger.exception(e);
+          }
+      }
+    }
+    try {
+      XmlUtil.saveDocument(new Document(root), new FileOutputStream(output));
+    } catch (IOException e) {
+      buildLogger.exception(e);
+    }
+  }
+
+  private static int readIntLE(RandomAccessFile file, long position) throws IOException {
+    file.seek(position);
+    byte[] bytes = new byte[4];
+    int bytesRead = file.read(bytes);
+    if (bytesRead != bytes.length) {
+      throw new EOFException();
+    }
+    return (bytes[0]&0xff) +
+          ((bytes[1]&0xff)<<8) +
+          ((bytes[2]&0xff)<<16) +
+          ((bytes[3]&0xff)<<24);
   }
 
   private File dumpPathsToFile(Collection<File> files) throws IOException {

--- a/agent/src/jetbrains/buildServer/symbols/tools/JetSymbolsExe.java
+++ b/agent/src/jetbrains/buildServer/symbols/tools/JetSymbolsExe.java
@@ -63,7 +63,8 @@ public class JetSymbolsExe {
         int size = readIntLE(randomAccess, peOffset + 80);
         String signature = Integer.toHexString(timestamp) + Integer.toHexString(size);
         final Element entry = new Element("file-sign-entry");
-        entry.setAttribute("file", file.getPath());
+        entry.setAttribute("file-path", file.getPath());
+        entry.setAttribute("file", file.getName());
         entry.setAttribute("sign", signature);
         root.addContent(entry);
       } catch (IOException e) {

--- a/agent/src/jetbrains/buildServer/symbols/tools/JetSymbolsExe.java
+++ b/agent/src/jetbrains/buildServer/symbols/tools/JetSymbolsExe.java
@@ -5,9 +5,6 @@ import jetbrains.buildServer.ExecResult;
 import jetbrains.buildServer.SimpleCommandLineProcessRunner;
 import jetbrains.buildServer.agent.BuildProgressLogger;
 import jetbrains.buildServer.util.FileUtil;
-import jetbrains.buildServer.util.XmlUtil;
-import org.jdom.Document;
-import org.jdom.Element;
 
 import java.io.*;
 import java.util.Collection;
@@ -48,55 +45,6 @@ public class JetSymbolsExe {
       }
     }
     return exitCode;
-  }
-
-  public void dumpBinaryGuidsToFile(Collection<File> files, File output, BuildProgressLogger buildLogger)
-  {
-    final Element root = new Element("file-signs");
-    for (File file : files) {
-      RandomAccessFile randomAccess = null;
-      try {
-        randomAccess = new RandomAccessFile(file, "r");
-        //the PE offset is at byte [60,64)
-        int peOffset = readIntLE(randomAccess, 60);
-        int timestamp = readIntLE(randomAccess, peOffset + 8);
-        int size = readIntLE(randomAccess, peOffset + 80);
-        String signature = Integer.toHexString(timestamp) + Integer.toHexString(size);
-        final Element entry = new Element("file-sign-entry");
-        entry.setAttribute("file-path", file.getPath());
-        entry.setAttribute("file", file.getName());
-        entry.setAttribute("sign", signature);
-        root.addContent(entry);
-      } catch (IOException e) {
-        buildLogger.exception(e);
-      } finally {
-        if (randomAccess != null)
-          try {
-            randomAccess.close();
-          } catch (IOException e) {
-            //I hate you, checked exceptions
-            buildLogger.exception(e);
-          }
-      }
-    }
-    try {
-      XmlUtil.saveDocument(new Document(root), new FileOutputStream(output));
-    } catch (IOException e) {
-      buildLogger.exception(e);
-    }
-  }
-
-  private static int readIntLE(RandomAccessFile file, long position) throws IOException {
-    file.seek(position);
-    byte[] bytes = new byte[4];
-    int bytesRead = file.read(bytes);
-    if (bytesRead != bytes.length) {
-      throw new EOFException();
-    }
-    return (bytes[0]&0xff) +
-          ((bytes[1]&0xff)<<8) +
-          ((bytes[2]&0xff)<<16) +
-          ((bytes[3]&0xff)<<24);
   }
 
   private File dumpPathsToFile(Collection<File> files) throws IOException {

--- a/common/src/jetbrains/buildServer/symbols/PdbSignatureIndexUtil.java
+++ b/common/src/jetbrains/buildServer/symbols/PdbSignatureIndexUtil.java
@@ -23,13 +23,13 @@ class PdbSignatureIndexUtil {
   private static final String FILE_SIGN_ENTRY = "file-sign-entry";
 
   @NotNull
-  static Set<PdbSignatureIndexEntry> read(@NotNull final InputStream inputStream) throws JDOMException, IOException {
+  static Set<PdbSignatureIndexEntry> read(@NotNull final InputStream inputStream, final boolean withDebugType) throws JDOMException, IOException {
     final SAXBuilder builder = new SAXBuilder();
     final Document document = builder.build(inputStream);
     final Set<PdbSignatureIndexEntry> result = new HashSet<PdbSignatureIndexEntry>();
     for (Object signElementObject : document.getRootElement().getChildren()){
       final Element signElement = (Element) signElementObject;
-      result.add(new PdbSignatureIndexEntry(extractGuid(signElement.getAttributeValue(SIGN)), signElement.getAttributeValue(FILE_NAME), signElement.getAttributeValue(FILE_PATH)));
+      result.add(new PdbSignatureIndexEntry(extractGuid(signElement.getAttributeValue(SIGN), withDebugType), signElement.getAttributeValue(FILE_NAME), signElement.getAttributeValue(FILE_PATH)));
     }
     return result;
   }
@@ -49,7 +49,10 @@ class PdbSignatureIndexUtil {
     XmlUtil.saveDocument(new Document(root), outputStream);
   }
 
-  private static String extractGuid(String sign) {
-    return sign.substring(0, sign.length() - 1).toLowerCase(); //last symbol is PEDebugType
+  private static String extractGuid(String sign, boolean withDebugType) {
+    if (withDebugType)
+      return sign.substring(0, sign.length() - 1).toLowerCase(); //last symbol is PEDebugType
+    else
+      return sign.toLowerCase();
   }
 }

--- a/common/src/jetbrains/buildServer/symbols/PdbSignatureIndexUtil.java
+++ b/common/src/jetbrains/buildServer/symbols/PdbSignatureIndexUtil.java
@@ -49,8 +49,8 @@ class PdbSignatureIndexUtil {
     XmlUtil.saveDocument(new Document(root), outputStream);
   }
 
-  private static String extractGuid(String sign, boolean withDebugType) {
-    if (withDebugType)
+  private static String extractGuid(String sign, boolean cutDebugType) {
+    if (cutDebugType)
       return sign.substring(0, sign.length() - 1).toLowerCase(); //last symbol is PEDebugType
     else
       return sign.toLowerCase();

--- a/common/src/jetbrains/buildServer/symbols/SymbolsConstants.java
+++ b/common/src/jetbrains/buildServer/symbols/SymbolsConstants.java
@@ -13,4 +13,5 @@ public class SymbolsConstants {
   public static final String APP_SOURCES = "/app/sources/";
 
   public static final String SYMBOL_SIGNATURES_FILE_NAME_PREFIX = "symbol-signatures-artifacts-";
+  public static final String BINARY_SIGNATURES_FILE_NAME_PREFIX = "binary-signatures-artifacts-";
 }

--- a/jet-symbols/src/JetBrains.CommandLine.Symbols/DumpFilesSignCommandBase.cs
+++ b/jet-symbols/src/JetBrains.CommandLine.Symbols/DumpFilesSignCommandBase.cs
@@ -51,7 +51,8 @@ namespace JetBrains.CommandLine.Symbols
       foreach (KeyValuePair<FileSystemPath, string> signature in signatures)
       {
         XmlElement element = node.CreateElement("file-sign-entry");
-        element.CreateAttributeWithNonEmptyValue("file", signature.Key.FullPath);
+        element.CreateAttributeWithNonEmptyValue("file-path", signature.Key.FullPath);
+        element.CreateAttributeWithNonEmptyValue("file", signature.Key.Name);
         string str = signature.Value;
         if (str != null)
           element.CreateAttributeWithNonEmptyValue("sign", str);

--- a/server/src/jetbrains/buildServer/symbols/BuildSymbolsIndexProvider.java
+++ b/server/src/jetbrains/buildServer/symbols/BuildSymbolsIndexProvider.java
@@ -40,50 +40,53 @@ public class BuildSymbolsIndexProvider implements BuildMetadataProvider {
     final long buildId = sBuild.getBuildId();
 
     final BuildArtifact symbols = sBuild.getArtifacts(BuildArtifactsViewMode.VIEW_HIDDEN_ONLY).getArtifact(".teamcity/symbols");
-    final BuildArtifact symbolSignaturesSource = symbols == null ? null : CollectionsUtil.findFirst(symbols.getChildren(), new Filter<BuildArtifact>() {
-      public boolean accept(@NotNull BuildArtifact data) {
-        return data.getName().startsWith(SymbolsConstants.SYMBOL_SIGNATURES_FILE_NAME_PREFIX);
+    int numSymbolFiles = 0;
+    for (BuildArtifact symbolSignaturesSource : symbols.getChildren())
+    {
+      if (!symbolSignaturesSource.getName().startsWith(SymbolsConstants.SYMBOL_SIGNATURES_FILE_NAME_PREFIX) &&
+              !symbolSignaturesSource.getName().startsWith(SymbolsConstants.BINARY_SIGNATURES_FILE_NAME_PREFIX))
+        continue;
+
+      Set<PdbSignatureIndexEntry> indexEntries = Collections.emptySet();
+      try {
+        indexEntries = PdbSignatureIndexUtil.read(symbolSignaturesSource.getInputStream());
+      } catch (IOException e) {
+        LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
+      } catch (JDOMException e) {
+        LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
       }
-    });
-    if(symbolSignaturesSource == null) {
-      LOG.debug("Build with id " + buildId + " doesn't provide symbols index data.");
-      return;
-    }
 
-    Set<PdbSignatureIndexEntry> indexEntries = Collections.emptySet();
-    try {
-      indexEntries = PdbSignatureIndexUtil.read(symbolSignaturesSource.getInputStream());
-    } catch (IOException e) {
-      LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
-    } catch (JDOMException e) {
-      LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
-    }
+      LOG.debug(String.format("Build with id %d provides %d symbol file signatures.", buildId, indexEntries.size()));
 
-    LOG.debug(String.format("Build with id %d provides %d symbol file signatures.", buildId, indexEntries.size()));
-
-    for (final PdbSignatureIndexEntry indexEntry : indexEntries) {
-      final String signature = indexEntry.getGuid();
-      final String fileName = indexEntry.getFileName();
-      String artifactPath = indexEntry.getArtifactPath();
-      if(artifactPath == null){
-        LOG.debug(String.format("Artifact path is not provided for artifact %s, locating it by name in build %s artifacts.", fileName, LogUtil.describe(sBuild)));
-        artifactPath = locateArtifact(sBuild, fileName);
-        if(artifactPath != null){
-          LOG.debug(String.format("Located artifact by name %s, path - %s. Build - %s", fileName, artifactPath, LogUtil.describe(sBuild)));
+      for (final PdbSignatureIndexEntry indexEntry : indexEntries) {
+        final String signature = indexEntry.getGuid();
+        final String fileName = indexEntry.getFileName();
+        String artifactPath = indexEntry.getArtifactPath();
+        if(artifactPath == null){
+          LOG.debug(String.format("Artifact path is not provided for artifact %s, locating it by name in build %s artifacts.", fileName, LogUtil.describe(sBuild)));
+          artifactPath = locateArtifact(sBuild, fileName);
+          if(artifactPath != null){
+            LOG.debug(String.format("Located artifact by name %s, path - %s. Build - %s", fileName, artifactPath, LogUtil.describe(sBuild)));
+          }
         }
+        final HashMap<String, String> data = new HashMap<String, String>();
+        data.put(FILE_NAME_KEY, fileName);
+        data.put(ARTIFACT_PATH_KEY, artifactPath);
+        metadataStorageWriter.addParameters(signature, data);
+        LOG.debug("Stored symbol file signature " + signature + " for file name " + fileName + " build id " + buildId);
       }
-      final HashMap<String, String> data = new HashMap<String, String>();
-      data.put(FILE_NAME_KEY, fileName);
-      data.put(ARTIFACT_PATH_KEY, artifactPath);
-      metadataStorageWriter.addParameters(signature, data);
-      LOG.debug("Stored symbol file signature " + signature + " for file name " + fileName + " build id " + buildId);
+      ++numSymbolFiles;
+    }
+
+    if(numSymbolFiles == 0) {
+      LOG.debug("Build with id " + buildId + " doesn't provide symbols index data.");
     }
   }
 
   @Nullable
   private String locateArtifact(@NotNull SBuild build, final @NotNull String artifactName) {
     final AtomicReference<String> locatedArtifactPath = new AtomicReference<String>(null);
-    build.getArtifacts(BuildArtifactsViewMode.VIEW_DEFAULT_WITH_ARCHIVES_CONTENT).iterateArtifacts(new BuildArtifacts.BuildArtifactsProcessor() {
+    build.getArtifacts(BuildArtifactsViewMode.VIEW_ALL_WITH_ARCHIVES_CONTENT).iterateArtifacts(new BuildArtifacts.BuildArtifactsProcessor() {
       @NotNull
       public Continuation processBuildArtifact(@NotNull BuildArtifact artifact) {
         if(artifact.getName().equals(artifactName)){

--- a/server/src/jetbrains/buildServer/symbols/BuildSymbolsIndexProvider.java
+++ b/server/src/jetbrains/buildServer/symbols/BuildSymbolsIndexProvider.java
@@ -47,14 +47,14 @@ public class BuildSymbolsIndexProvider implements BuildMetadataProvider {
               !symbolSignaturesSource.getName().startsWith(SymbolsConstants.BINARY_SIGNATURES_FILE_NAME_PREFIX))
         continue;
 
-      Set<PdbSignatureIndexEntry> indexEntries = Collections.emptySet();
-      try {
-        indexEntries = PdbSignatureIndexUtil.read(symbolSignaturesSource.getInputStream());
-      } catch (IOException e) {
-        LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
-      } catch (JDOMException e) {
-        LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
-      }
+    Set<PdbSignatureIndexEntry> indexEntries = Collections.emptySet();
+    try {
+      indexEntries = PdbSignatureIndexUtil.read(symbolSignaturesSource.getInputStream(), false);
+    } catch (IOException e) {
+      LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
+    } catch (JDOMException e) {
+      LOG.debug("Failed to read symbols index data from artifact " + symbolSignaturesSource.getRelativePath(), e);
+    }
 
       LOG.debug(String.format("Build with id %d provides %d symbol file signatures.", buildId, indexEntries.size()));
 

--- a/server/src/jetbrains/buildServer/symbols/DownloadSymbolsController.java
+++ b/server/src/jetbrains/buildServer/symbols/DownloadSymbolsController.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class DownloadSymbolsController extends BaseController {
 
-  private static final String COMPRESSED_FILE_EXTENSION = "pd_";
+  private static final String COMPRESSED_FILE_EXTENSION = "_";
   private static final String FILE_POINTER_FILE_EXTENSION = "ptr";
 
   private static final Logger LOG = Logger.getLogger(DownloadSymbolsController.class);
@@ -156,7 +156,7 @@ public class DownloadSymbolsController extends BaseController {
       LOG.debug(String.format("Build not found by id %d.", buildId));
       return null;
     }
-    final BuildArtifact buildArtifact = build.getArtifacts(BuildArtifactsViewMode.VIEW_DEFAULT_WITH_ARCHIVES_CONTENT).getArtifact(storedArtifactPath);
+    final BuildArtifact buildArtifact = build.getArtifacts(BuildArtifactsViewMode.VIEW_ALL_WITH_ARCHIVES_CONTENT).getArtifact(storedArtifactPath);
     if(buildArtifact == null){
       LOG.debug(String.format("Artifact not found by path %s for build with id %d.", storedArtifactPath, buildId));
     }


### PR DESCRIPTION
This patch contains code for saving signatures of binaries, so the symbol server is more useful when examining minidumps.

It also changes the search behavior to index hidden artifacts as well as default visible artifacts.

I am not a Java programmer, so if I did something stupid let me know.
