### PR TITLE
Disambiguate binary signatures by filename too

### DIFF
--- a/agent/src/jetbrains/buildServer/symbols/tools/BinaryGuidDumper.java
+++ b/agent/src/jetbrains/buildServer/symbols/tools/BinaryGuidDumper.java
@@ -26,7 +26,8 @@ public class BinaryGuidDumper {
                 final Element entry = new Element("file-sign-entry");
                 entry.setAttribute("file-path", file.getPath());
                 entry.setAttribute("file", file.getName());
-                entry.setAttribute("sign", signature);
+                // Multiple binaries can share the same signature, so disambiguate them by filename
+                entry.setAttribute("sign", file.getName() + "-" + signature);
                 root.addContent(entry);
             } catch (IOException e) {
                 buildLogger.exception(e);

--- a/agent/src/jetbrains/buildServer/symbols/tools/BinaryGuidDumper.java
+++ b/agent/src/jetbrains/buildServer/symbols/tools/BinaryGuidDumper.java
@@ -26,8 +26,7 @@ public class BinaryGuidDumper {
                 final Element entry = new Element("file-sign-entry");
                 entry.setAttribute("file-path", file.getPath());
                 entry.setAttribute("file", file.getName());
-                // Multiple binaries can share the same signature, so disambiguate them by filename
-                entry.setAttribute("sign", file.getName() + "-" + signature);
+                entry.setAttribute("sign", signature);
                 root.addContent(entry);
             } catch (IOException e) {
                 buildLogger.exception(e);

--- a/server/src/jetbrains/buildServer/symbols/DownloadSymbolsController.java
+++ b/server/src/jetbrains/buildServer/symbols/DownloadSymbolsController.java
@@ -142,7 +142,7 @@ public class DownloadSymbolsController extends BaseController {
     final Map<String,String> metadata = entry.getMetadata();
     final String storedArtifactPath = metadata.get(BuildSymbolsIndexProvider.ARTIFACT_PATH_KEY);
     if(storedArtifactPath == null){
-      LOG.debug(String.format("Metadata stored for guid '%s' is invalid.", entry.getKey());
+      LOG.debug(String.format("Metadata stored for guid '%s' is invalid.", entry.getKey()));
       return null;
     }
 

--- a/server/src/jetbrains/buildServer/symbols/DownloadSymbolsController.java
+++ b/server/src/jetbrains/buildServer/symbols/DownloadSymbolsController.java
@@ -88,7 +88,13 @@ public class DownloadSymbolsController extends BaseController {
     final String guid = signature.substring(0, signature.length() - 1).toLowerCase(); //last symbol is PEDebugType
     LOG.debug(String.format("Symbol file requested. File name: %s. Guid: %s.", fileName, guid));
 
-    final String projectId = findRelatedProjectId(guid, fileName);
+    final BuildMetadataEntry metadataEntry = getMetadataEntry(guid, fileName);
+    if(metadataEntry == null) {
+      LOG.debug(String.format("There is no information about symbol file %s with id %s in the index.", fileName, guid));
+      WebUtil.notFound(request, response, "File not found", null);
+      return null;
+    }
+    final String projectId = findRelatedProjectId(metadataEntry);
     if(projectId == null) {
       WebUtil.notFound(request, response, "File not found", null);
       return null;
@@ -104,7 +110,7 @@ public class DownloadSymbolsController extends BaseController {
     try {
       mySecurityContext.runAs(user, new SecurityContextEx.RunAsAction() {
         public void run() throws Throwable {
-          final BuildArtifact buildArtifact = findArtifact(guid, fileName);
+          final BuildArtifact buildArtifact = findArtifact(metadataEntry);
           if(buildArtifact == null){
             WebUtil.notFound(request, response, "Symbol file not found", null);
             LOG.debug(String.format("Symbol file not found. File name: %s. Guid: %s.", fileName, guid));
@@ -132,21 +138,11 @@ public class DownloadSymbolsController extends BaseController {
   }
 
   @Nullable
-  private BuildArtifact findArtifact(String guid, String fileName) {
-    final BuildMetadataEntry entry = getMetadataEntry(guid, fileName);
-    if(entry == null) {
-      LOG.debug(String.format("No items found in symbol index for guid '%s'", guid));
-      return null;
-    }
+  private BuildArtifact findArtifact(@NotNull BuildMetadataEntry entry) {
     final Map<String,String> metadata = entry.getMetadata();
     final String storedArtifactPath = metadata.get(BuildSymbolsIndexProvider.ARTIFACT_PATH_KEY);
-    final String storedFileName = metadata.get(BuildSymbolsIndexProvider.FILE_NAME_KEY);
-    if(storedFileName == null || storedArtifactPath == null){
-      LOG.debug(String.format("Metadata stored for guid '%s' is invalid.", guid));
-      return null;
-    }
-    if(!storedFileName.equalsIgnoreCase(fileName)){
-      LOG.debug(String.format("File name '%s' stored for guid '%s' differs from requested '%s'.", storedFileName, guid, fileName));
+    if(storedArtifactPath == null){
+      LOG.debug(String.format("Metadata stored for guid '%s' is invalid.", entry.getKey());
       return null;
     }
 
@@ -164,33 +160,29 @@ public class DownloadSymbolsController extends BaseController {
   }
 
   @Nullable
-  private String findRelatedProjectId(String symbolFileId, String fileName) {
-    final BuildMetadataEntry metadataEntry = getMetadataEntry(symbolFileId, fileName);
-    if(metadataEntry == null) {
-      LOG.debug(String.format("There is no information about symbol file with id %s in the index.", symbolFileId));
-      return null;
-    }
+  private String findRelatedProjectId(@NotNull BuildMetadataEntry metadataEntry) {
     long buildId = metadataEntry.getBuildId();
     final SBuild build = myServer.findBuildInstanceById(buildId);
     if(build == null) {
-      LOG.debug(String.format("Failed to find build by id %d. Requested symbol file with id %s expected to be produced by that build.", buildId, symbolFileId));
+      LOG.debug(String.format("Failed to find build by id %d. Requested symbol file with id %s expected to be produced by that build.", buildId, metadataEntry.getKey()));
       return null;
     }
     return build.getProjectId();
   }
 
   @Nullable
-  private BuildMetadataEntry getMetadataEntry(String guid, String fileName) {
-    final BuildMetadataEntry disambiguatedEntry = getMetadataEntry(fileName.toLowerCase() + "-" + guid);
-    // Use the disambiguated guid if it exists, otherwise use the bare guid
-    if (disambiguatedEntry != null)
-      return disambiguatedEntry;
-    return getMetadataEntry(guid);
-  }
-
-  @Nullable
-  private BuildMetadataEntry getMetadataEntry(String key){
+  private BuildMetadataEntry getMetadataEntry(@NotNull String key, String fileName){
+      if (fileName == null)
+        return null;
     final Iterator<BuildMetadataEntry> entryIterator = myBuildMetadataStorage.getEntriesByKey(BuildSymbolsIndexProvider.PROVIDER_ID, key);
-    return !entryIterator.hasNext() ? null : entryIterator.next();
+    while (entryIterator.hasNext()) {
+      final BuildMetadataEntry entry = entryIterator.next();
+      if (entry == null)
+        continue;
+      final String entryFileName = entry.getMetadata().get(BuildSymbolsIndexProvider.FILE_NAME_KEY);
+      if (fileName.equalsIgnoreCase(entryFileName))
+          return entry;
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Binary signatures are not random, but are instead generated from the
build time and mapping size.  A fast build machine can easily build 2
binaries in the same second, which can cause them to both have the same
signature, which would prevent the symbol server from serving them both
up independently.  With this change, the binaries can have different
signatures and so will both be available.

This can be reproduced by building `f.msbuild` from the test repository at https://github.com/marc-groundctl/didactic-journey