### PR TITLE
Allow the user to override the source files path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ RUN Invoke-WebRequest https://download.microsoft.com/download/5/A/0/5A08CEF4-3EC
     Remove-Item -Force winsdksetup.exe
 ```
 
+### Overriding source server paths
+
+If the URL of your Teamcity server changes, source indexing will not work for old builds because the old PDB files will still be referencing the old Teamcity URL.  To fix this, you can override the Teamcity source path using the [srcsrv.ini file](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/the-srcsrv-ini-file#using_a_different_location_or_file_name).  In the `[variables]` section, set `TEAMCITY_BASE_PATH` to the sources path of the new Teamcity server.  For example:
+
+```ini
+[variables]
+TEAMCITY_BASE_PATH=https://new_teamcity.example.com/app/sources
+```
+
 ## Common Problems
 
 ### Failed to find Source Server tools home directory

--- a/teamcity-symbol-agent/src/main/java/jetbrains/buildServer/symbols/FileUrlProvider.java
+++ b/teamcity-symbol-agent/src/main/java/jetbrains/buildServer/symbols/FileUrlProvider.java
@@ -24,8 +24,12 @@ public class FileUrlProvider {
     mySourcesRootDirectoryCanonicalPath = FileUtil.getCanonicalFile(sourcesRootDirectory).getPath();
   }
 
-  public String getHttpAlias() {
-    return String.format("%s/builds/id-%d/sources/files", myUrlPrefix, myBuildId);
+  public String getBuildPath() {
+    return String.format("builds/id-%d/sources/files", myBuildId);
+  }
+
+  public String getBasePath() {
+    return myUrlPrefix;
   }
 
   @Nullable

--- a/teamcity-symbol-agent/src/main/java/jetbrains/buildServer/symbols/SrcSrvStreamBuilder.java
+++ b/teamcity-symbol-agent/src/main/java/jetbrains/buildServer/symbols/SrcSrvStreamBuilder.java
@@ -32,8 +32,7 @@ public class SrcSrvStreamBuilder {
       fileWriter.write("SRCSRV: variables ------------------------------------------\r\n");
       fileWriter.write("SRCSRVVERCTRL=http\r\n");
       fileWriter.write(String.format("TEAMCITY_BASE_PATH=%s\r\n", myUrlProvider.getBasePath()));
-      fileWriter.write(String.format("TEAMCITY_BUILD_PATH=%s\r\n", myUrlProvider.getBuildPath()));
-      fileWriter.write("HTTP_ALIAS=%TEAMCITY_BASE_PATH%/%TEAMCITY_BUILD_PATH%\r\n");
+      fileWriter.write(String.format("HTTP_ALIAS=%TEAMCITY_BASE_PATH%/%s\r\n", myUrlProvider.getBuildPath()));
       fileWriter.write("HTTP_EXTRACT_TARGET=%HTTP_ALIAS%/%var2%\r\n");
       fileWriter.write("SRCSRVTRG=%HTTP_EXTRACT_TARGET%\r\n");
       fileWriter.write("SRCSRVCMD=\r\n");

--- a/teamcity-symbol-agent/src/main/java/jetbrains/buildServer/symbols/SrcSrvStreamBuilder.java
+++ b/teamcity-symbol-agent/src/main/java/jetbrains/buildServer/symbols/SrcSrvStreamBuilder.java
@@ -31,7 +31,9 @@ public class SrcSrvStreamBuilder {
       fileWriter.write("VERCTRL=http\r\n");
       fileWriter.write("SRCSRV: variables ------------------------------------------\r\n");
       fileWriter.write("SRCSRVVERCTRL=http\r\n");
-      fileWriter.write(String.format("HTTP_ALIAS=%s\r\n", myUrlProvider.getHttpAlias()));
+      fileWriter.write(String.format("TEAMCITY_BASE_PATH=%s\r\n", myUrlProvider.getBasePath()));
+      fileWriter.write(String.format("TEAMCITY_BUILD_PATH=%s\r\n", myUrlProvider.getBuildPath()));
+      fileWriter.write("HTTP_ALIAS=%TEAMCITY_BASE_PATH%/%TEAMCITY_BUILD_PATH%\r\n");
       fileWriter.write("HTTP_EXTRACT_TARGET=%HTTP_ALIAS%/%var2%\r\n");
       fileWriter.write("SRCSRVTRG=%HTTP_EXTRACT_TARGET%\r\n");
       fileWriter.write("SRCSRVCMD=\r\n");


### PR DESCRIPTION
This allows the user to change their teamcity URL and still be able to
get the sources from builds made on the old URL.